### PR TITLE
Changed input format

### DIFF
--- a/nirikshak/controller/base.py
+++ b/nirikshak/controller/base.py
@@ -40,11 +40,11 @@ def worker(queue, soochi):
     else:
         LOG.info("Loading worker modules.")
 
-    for name, jaanch in soochi['jaanches'].items():
+    for jaanch in soochi['jaanches']:
         try:
-            queue.put({name: base_worker.do_work(**{name: jaanch})})
+            queue.put(base_worker.do_work(**jaanch))
         except Exception:
-            LOG.error("%s jaanch failed to get executed", name)
+            LOG.error("%s jaanch failed to get executed", jaanch['name'])
 
 
 def _get_workers_pool():
@@ -114,7 +114,7 @@ def _merge_configs(soochis_def):
     for soochis in soochis_def:
         config = soochis[0]
         for jaanch in soochis[1]['jaanches']:
-            utils.merge_dict(soochis[1]['jaanches'][jaanch], config)
+            utils.merge_dict(jaanch, config)
         new_def.append(soochis[1])
 
     return new_def

--- a/nirikshak/output/base.py
+++ b/nirikshak/output/base.py
@@ -30,39 +30,39 @@ class FormatOutput(object):
         pass
 
 
-def output(**kwargs):
-    jaanch_parameters = list(kwargs.values())[0]
+def output(**jaanch_parameters):
     output_plugin = jaanch_parameters.get('output', {}).get('type', 'console')
 
     # NOTE(thenakliman): if plugin is not registered then it returns kwargs
     plugin = plugins.get_plugin(output_plugin)
-    soochis = kwargs
+    soochis = jaanch_parameters
     try:
-        soochis = getattr(plugin, 'output')(**kwargs)
+        soochis = getattr(plugin, 'output')(**jaanch_parameters)
     except Exception:
         LOG.error("%s jaanch get failed for %s output.",
-                  list(kwargs.keys())[0], output_plugin, exc_info=True)
+                  jaanch_parameters['name'], output_plugin, exc_info=True)
     else:
         LOG.info("%s soochis has been returned by the plugin", soochis)
 
     return soochis
 
 
-def make_output_dict(key, expected_result, **kwargs):
+def make_output_dict(expected_result, **kwargs):
     output_dict = {}
     try:
-        output_dict = {'actual_output': kwargs[key]['input']['result']}
+        output_dict = {'actual_output': kwargs['input']['result']}
     except KeyError:
         LOG.error("result key does not exist in the dictionary")
 
     if expected_result is not None:
         output_dict['expected_output'] = expected_result
 
-    jaanch = {key: {}}
+    jaanch = {}
     try:
-        jaanch[key]['input'] = kwargs[key]['input']['args']
+        jaanch['input'] = kwargs['input']['args']
     except KeyError:
         pass
 
-    jaanch[key]['output'] = output_dict
+    jaanch['name'] = kwargs['name']
+    jaanch['output'] = output_dict
     return jaanch

--- a/nirikshak/output/dump_json.py
+++ b/nirikshak/output/dump_json.py
@@ -55,17 +55,16 @@ class JSONFormatOutput(base.FormatOutput):
             out_file = '/var/lib/nirikshak/result.json'
 
         output_file = self.get_output_file(out_file)
-        key = list(kwargs.keys())[0]
         try:
-            expected_result = kwargs[key]['output']['result']
+            expected_result = kwargs['output']['result']
         except KeyError:
             expected_result = None
 
-        jaanch = base.make_output_dict(key, expected_result, **kwargs)
+        jaanch = base.make_output_dict(expected_result, **kwargs)
         if not output_file:
-            output_file = jaanch
+            output_file = [jaanch]
         else:
-            output_file.update(jaanch)
+            output_file.append(jaanch)
 
         self._output_json(output_file, out_file)
         LOG.info("Output has been dumped in %s", out_file)

--- a/nirikshak/output/dump_yaml.py
+++ b/nirikshak/output/dump_yaml.py
@@ -56,17 +56,16 @@ class YAMLFormatOutput(base.FormatOutput):
             out_file = '/var/lib/nirikshak/result.yaml'
 
         output_file = self.read_file(out_file)
-        key = list(kwargs.keys())[0]
         try:
-            expected_result = kwargs[key]['output']['result']
+            expected_result = kwargs['output']['result']
         except KeyError:
             expected_result = None
 
-        jaanch = base.make_output_dict(key, expected_result, **kwargs)
+        jaanch = base.make_output_dict(expected_result, **kwargs)
         if not output_file:
-            output_file = jaanch
+            output_file = [jaanch]
         else:
-            output_file.update(jaanch)
+            output_file.append(jaanch)
 
         self._write_file(output_file, out_file)
         LOG.info("Output has been dumped in %s file", out_file)

--- a/nirikshak/output/send.py
+++ b/nirikshak/output/send.py
@@ -36,12 +36,11 @@ class NetworkSendOutput(base.FormatOutput):
         protocol = nirikshak.CONF[SECTION].get('protocol', 'http')
         url = nirikshak.CONF[SECTION].get('url', '')
         url = ("%s://%s:%s/%s" % (protocol, host, port, url))
-        key = list(kwargs.keys())[0]
         try:
-            expected_result = kwargs[key]['output']['result']
+            expected_result = kwargs['output']['result']
         except KeyError:
             expected_result = None
-        jaanch = base.make_output_dict(key, expected_result, **kwargs)
+        jaanch = base.make_output_dict(expected_result, **kwargs)
         payld = json.dumps(jaanch)
         try:
             getattr(requests, method)(url, data=payld)

--- a/nirikshak/post_task/base.py
+++ b/nirikshak/post_task/base.py
@@ -30,11 +30,10 @@ class FormatOutput(object):
 
 
 def format_for_output(**kwargs):
-    values = list(kwargs.values())[0]
-    if values.get('post_task', 'console') == 'console':
-        post_task = values.get('post_task', 'console')
+    if kwargs.get('post_task', 'console') == 'console':
+        post_task = kwargs.get('post_task', 'console')
     else:
-        post_task = values.get('post_task', 'dummy')
+        post_task = kwargs.get('post_task', 'dummy')
 
     plugin = plugins.get_plugin(post_task)
     soochis = None
@@ -45,9 +44,9 @@ def format_for_output(**kwargs):
         return kwargs
     except Exception:
         LOG.error("Error in formatting %s jaanch for %s post_task",
-                  list(kwargs.keys())[0], post_task, exc_info=True)
+                  kwargs['name'], post_task, exc_info=True)
     else:
         LOG.info("%s jaanch has been formatter by %s plugin",
-                 list(kwargs.keys())[0], post_task)
+                 kwargs['name'], post_task)
 
     return soochis

--- a/nirikshak/tests/unit/base.py
+++ b/nirikshak/tests/unit/base.py
@@ -48,8 +48,8 @@ def get_main_yaml():
 
 def get_test_keystone_soochi():
     jaanches = {
-        'jaanches': {
-            'port_5000': {
+        'jaanches': [{
+                'name': 'port_5000',
                 'type': 'file',
                 'post_task': 'console',
                 'input': {
@@ -62,7 +62,8 @@ def get_test_keystone_soochi():
                     'type': 'console'
                 }
             },
-            'port_35357': {
+            {
+                'name': 'port_3537',
                 'type': 'file',
                 'post_task': 'console',
                 'input': {
@@ -74,8 +75,7 @@ def get_test_keystone_soochi():
                 'output': {
                     'type': 'console'
                     }
-                }
-            }
+            }]
         }
 
     return jaanches
@@ -83,8 +83,8 @@ def get_test_keystone_soochi():
 
 def get_test_glance_soochi():
     jaanches = {
-        'jaanches': {
-            'port_9292': {
+        'jaanches': [{
+                'name': 'port_9292',
                 'type': 'file',
                 'post_task': 'console',
                 'input': {
@@ -97,7 +97,8 @@ def get_test_glance_soochi():
                     'type': 'console'
                 }
             },
-            'port_1234': {
+            {
+                'name': 'port_1234',
                 'type': 'file',
                 'post_task': 'console',
                 'input': {
@@ -110,7 +111,7 @@ def get_test_glance_soochi():
                     'type': 'console'
                 }
             }
-        }
+        ]
     }
 
     return jaanches
@@ -132,6 +133,7 @@ def create_conf():
 
 def get_disk_jaanch():
     jaanch = {
+        'name': 'disk_jaanch',
         'type': 'disk_partition',
         'input': {
             'args': {
@@ -147,6 +149,7 @@ def get_disk_jaanch():
 
 def get_ini_jaanch():
     jaanch = {
+        'name': 'ini_jaanch',
         'type': 'ini',
         'input': {
             'args': {

--- a/nirikshak/tests/unit/controller/test_base.py
+++ b/nirikshak/tests/unit/controller/test_base.py
@@ -40,11 +40,11 @@ class WorkerTest(unittest.TestCase):
     def _get_fake_jaanch():
         return [
             [{'key1': 'value1'},
-             {'jaanches':
-                 {'jaanch1': {'jaanch1_param': 'jaanch1_body'}}}],
+             {'jaanches': [
+                 {'name': 'jaanch1', 'jaanch1_param': 'jaanch1_body'}]}],
             [{'key2': 'value2'}, {
-                'jaanches': {
-                    'jaanch2': {'jaanch2_param': 'jaanch2_body', 'k2': 'v2'}}}]
+                'jaanches': [{
+                    'name': 'jaanch2', 'jaanch2_param': 'jaanch2_body', 'k2': 'v2'}]}]
         ]
 
     @mock.patch.object(base_post_task, 'format_for_output')
@@ -72,8 +72,7 @@ class WorkerTest(unittest.TestCase):
         base_controller.execute(soochis=['soochi'], groups=['group'])
 
         mock_get_soochis.assert_called_once_with(['soochi'], ['group'])
-        post_task_calls = [mock.call(jaanch1={'work': True}),
-                           mock.call(jaanch2={'work': True})]
+        post_task_calls = [mock.call(work=True), mock.call(work=True)]
         mock_post_task.assert_has_calls(post_task_calls, any_order=True)
         mock_output = mock.call(work=True, post_task=True)
         mock_output.assert_has_calls([mock_output, mock_output])
@@ -89,8 +88,7 @@ class WorkerTest(unittest.TestCase):
         base_controller.execute(soochis=['soochi'], groups=['group'])
 
         mock_get_soochis.assert_called_once_with(['soochi'], ['group'])
-        post_task_calls = [mock.call(jaanch1={'work': True}),
-                           mock.call(jaanch2={'work': True})]
+        post_task_calls = [mock.call(work=True), mock.call(work=True)]
         mock_post_task.assert_has_calls(post_task_calls, any_order=True)
 
     @mock.patch.object(base_post_task, 'format_for_output',
@@ -130,13 +128,13 @@ class WorkerInvokeTest(unittest.TestCase):
     def test_worker_failed_in_queue_put(self, mock_load_worker,
                                         mock_do_worker):
 
-        jaanches = {'jaanches': {'fake_jaanch': 10}}
+        jaanches = {'jaanches': [{'name': 'fake_jaanch'}]}
         mock_queue = mock.Mock(put=mock.Mock(side_effect=Exception))
 
         base_controller.worker(mock_queue, jaanches)
 
         mock_load_worker.assert_called_once_with()
-        mock_do_worker.assert_called_with(**jaanches['jaanches'])
+        mock_do_worker.assert_called_with(name='fake_jaanch')
         mock_queue.put.assert_called_once()
 
     @mock.patch.object(base_worker, 'do_work')
@@ -147,11 +145,11 @@ class WorkerInvokeTest(unittest.TestCase):
             return 10
 
         mock_base_worker.side_effect = side_effect
-        jaanches = {'jaanches': {'fake_jaanch': 15}}
+        jaanches = {'jaanches': [{'name': 'fake_jaanch'}]}
         mock_queue = mock.Mock(put=mock.Mock())
 
         base_controller.worker(mock_queue, jaanches)
 
-        mock_base_worker.assert_called_with(**jaanches['jaanches'])
-        mock_queue.put.assert_called_once_with({'fake_jaanch': 10})
+        mock_base_worker.assert_called_with(name='fake_jaanch')
+        mock_queue.put.assert_called_once_with(10)
         mock_load_workers.assert_called_once_with()

--- a/nirikshak/tests/unit/controller/test_base.py
+++ b/nirikshak/tests/unit/controller/test_base.py
@@ -44,7 +44,8 @@ class WorkerTest(unittest.TestCase):
                  {'name': 'jaanch1', 'jaanch1_param': 'jaanch1_body'}]}],
             [{'key2': 'value2'}, {
                 'jaanches': [{
-                    'name': 'jaanch2', 'jaanch2_param': 'jaanch2_body', 'k2': 'v2'}]}]
+                    'name': 'jaanch2',
+                    'jaanch2_param': 'jaanch2_body', 'k2': 'v2'}]}]
         ]
 
     @mock.patch.object(base_post_task, 'format_for_output')

--- a/nirikshak/tests/unit/input/test_base.py
+++ b/nirikshak/tests/unit/input/test_base.py
@@ -127,12 +127,12 @@ class InputFileTest(base.BaseTestCase):
 
         exp_soochis = [base.get_test_keystone_soochi()]
         tmp = base.get_test_glance_soochi()
-        del tmp['jaanches']['port_9292']
+        tmp['jaanches'].pop(0)
         exp_soochis.append(tmp)
 
         for _, soochi in soochis:
-            if soochi['jaanches'].get('port_9292'):
-                del soochi['jaanches']['port_9292']
+            if soochi['jaanches'][0]['name'] == 'port_9292':
+                soochi['jaanches'].pop(0)
 
             self.assertIn(soochi, exp_soochis)
 

--- a/nirikshak/tests/unit/output/test_base.py
+++ b/nirikshak/tests/unit/output/test_base.py
@@ -77,7 +77,6 @@ class TestOutputBase(unittest.TestCase):
         fake_jaanch = get_fake_jaanch()
         exp_jaanch = copy.deepcopy(fake_jaanch)
         exp_jaanch['test_result'] = 'pass'
-        print(exp_jaanch, base.output(**fake_jaanch))
         self.assertDictEqual(exp_jaanch, base.output(**fake_jaanch))
         mock_info_log.assert_called()
 

--- a/nirikshak/tests/unit/output/test_json.py
+++ b/nirikshak/tests/unit/output/test_json.py
@@ -35,19 +35,18 @@ class JSONFormatOutputTest(base_test.BaseTestCase):
     @mock.patch.object(json, 'dumps')
     def test_conf_without_section(self, mock_output_json, mock_output_file):
         f_name = '/var/lib/nirikshak/result.json'
-        soochis = base_test.get_test_keystone_soochi()['jaanches']
-        mock_output_file.return_value = {'port_5000': soochis['port_5000']}
-        exp = {'port_35357': soochis['port_35357']}
+        soochi1, soochi2 = base_test.get_test_keystone_soochi()['jaanches']
+        mock_output_file.return_value = [soochi1]
         # fixme(thenakliman): mock open method properly
         with mock.patch.object(dump_json, 'open') as mock_open:
-            dump_json.JSONFormatOutput().output(**exp)
-        result = {
-            'port_35357': {
-                'input': soochis['port_35357']['input']['args'],
+            dump_json.JSONFormatOutput().output(**soochi2)
+        result = [soochi1]
+        result.append(
+            {
+                'name': 'port_3537',
+                'input': soochi2['input']['args'],
                 'output': {}
-            }
-        }
-        result.update({'port_5000': soochis['port_5000']})
+            })
         mock_output_file.assert_called_once_with(f_name)
         mock_output_json.assert_called_once_with(result, indent=4,
                                                  sort_keys=True,
@@ -60,18 +59,18 @@ class JSONFormatOutputTest(base_test.BaseTestCase):
         nirikshak.CONF['output_json'] = {'output_dir':
                                          '/var/nirikshak/result.json'}
         f_name = nirikshak.CONF['output_json']['output_dir']
-        soochis = base_test.get_test_keystone_soochi()['jaanches']
-        soochis['port_35357']['output']['result'] = 'test'
-        soochis['port_35357']['input']['result'] = 'test'
-        mock_output_file.return_value = {}
-        exp = {'port_35357': soochis['port_35357']}
-        dump_json.JSONFormatOutput().output(**exp)
-        result = {
-            'port_35357': {
-                'input': soochis['port_35357']['input']['args'],
+        soochi1, soochi2 = base_test.get_test_keystone_soochi()['jaanches']
+        soochi2['output']['result'] = 'test'
+        soochi2['input']['result'] = 'test'
+        mock_output_file.return_value = []
+        dump_json.JSONFormatOutput().output(**soochi2)
+        result = [
+            {
+                'name': 'port_3537',
+                'input': soochi2['input']['args'],
                 'output': {'actual_output': 'test', 'expected_output': 'test'}
             }
-        }
+        ]
         mock_output_file.assert_called_once_with(f_name)
         mock_output_json.assert_called_once_with(result, f_name)
 

--- a/nirikshak/tests/unit/output/test_send.py
+++ b/nirikshak/tests/unit/output/test_send.py
@@ -56,10 +56,10 @@ class TestSend(base_test.BaseTestCase):
     def test_output_send_fail(self, mock_base_make_dict, mock_json_dumps,
                               mock_put_request, mock_error_log):
 
-        data = {'jaanch': {'result': {}}}
+        data = {'result': {}}
 
-        def make_dict(key, exp, **kwargs):
-            kwargs[key]['result']['output'] = exp
+        def make_dict(exp, **kwargs):
+            kwargs['result']['output'] = exp
             return kwargs
 
         def dump_json(jaanch):
@@ -79,10 +79,10 @@ class TestSend(base_test.BaseTestCase):
     def test_output_send_pass(self, mock_base_make_dict, mock_json_dumps,
                               mock_put_request, mock_info_log):
 
-        data = {'jaanch': {'result': {}}}
+        data = {'result': {}}
 
-        def make_dict(key, exp, **kwargs):
-            kwargs[key]['result']['output'] = exp
+        def make_dict(exp, **kwargs):
+            kwargs['result']['output'] = exp
             return kwargs
 
         def dump_json(jaanch):

--- a/nirikshak/tests/unit/post_task/test_base.py
+++ b/nirikshak/tests/unit/post_task/test_base.py
@@ -25,7 +25,7 @@ def register_plugin():
     @plugins.register(PLUGIN_NAME)
     class DummyClass(base.FormatOutput):
         def format_output(self, **kwargs):
-            if kwargs.get('jaanch').get('raise_exception'):
+            if kwargs.get('raise_exception'):
                 raise Exception
 
             return ['soochis']
@@ -42,11 +42,10 @@ class TestFormatForOutput(unittest.TestCase):
 
     @staticmethod
     def _get_fake_jaanch():
-        fake_jaanch = {'jaanch': {}}
-        fake_jaanch['jaanch'] = {
+        return {
+            'name': 'fake_jaancn',
             'post_task': 'dummy_class'
         }
-        return fake_jaanch
 
     @mock.patch.object(base.LOG, 'info')
     def test_format_output_if_post_task_defined(self, mock_info_log):
@@ -57,18 +56,17 @@ class TestFormatForOutput(unittest.TestCase):
 
     @mock.patch.object(base.LOG, 'error')
     def test_format_output_if_post_task_not_defined(self, mock_error_log):
-        fake_jaanch = {'jaanch': {}}
-        self.assertEqual(base.format_for_output(**fake_jaanch), fake_jaanch)
+        self.assertEqual(base.format_for_output(**{'name': 'fake_jaanch'}),
+                         {'name': 'fake_jaanch'})
         mock_error_log.assert_called()
 
     @mock.patch.object(base.LOG, 'error')
     def test_format_output_if_error_occur_in_post_task(self, mock_error_log):
         register_plugin()
         fake_jaanch = {
-            'jaanch': {
+                'name': 'fake_jaanch',
                 'post_task': 'dummy_class',
                 'raise_exception': True
-                }
             }
         self.assertIsNone(base.format_for_output(**fake_jaanch))
         mock_error_log.assert_called()

--- a/nirikshak/tests/unit/workers/network/test_network_port.py
+++ b/nirikshak/tests/unit/workers/network/test_network_port.py
@@ -27,8 +27,7 @@ class WorkerTest(unittest.TestCase):
     def setUp(self):
         sample_jaanch = {}
         sample_jaanch = base.get_test_keystone_soochi()
-        sample_jaanch = sample_jaanch['jaanches']['port_5000']
-        self.sample_jaanch = sample_jaanch
+        self.sample_jaanch = sample_jaanch['jaanches'][0]
         super(WorkerTest, self).setUp()
 
     @mock.patch.object(socket, 'socket')

--- a/nirikshak/tests/unit/workers/test_base.py
+++ b/nirikshak/tests/unit/workers/test_base.py
@@ -24,7 +24,7 @@ from nirikshak.workers import base as worker_base
 class WorkBaseTest(unittest.TestCase):
     def setUp(self):
         super(WorkBaseTest, self).setUp()
-        self.sample_jaanch = {'jaanch': base.get_ini_jaanch()}
+        self.sample_jaanch = base.get_ini_jaanch()
 
     @property
     def jaanch(self):
@@ -32,8 +32,8 @@ class WorkBaseTest(unittest.TestCase):
 
     def test_if_type_not_defined(self):
         jaanch = self.jaanch
-        del jaanch['jaanch']['type']
-        self.assertDictEqual(jaanch['jaanch'], worker_base.do_work(**jaanch))
+        del jaanch['type']
+        self.assertDictEqual(jaanch, worker_base.do_work(**jaanch))
 
     @staticmethod
     def _register_plugin():
@@ -45,8 +45,7 @@ class WorkBaseTest(unittest.TestCase):
 
     def test_plugin_fails(self):
         self._register_plugin()
-        self.assertDictEqual(self.jaanch['jaanch'],
-                             worker_base.do_work(**self.jaanch))
+        self.assertDictEqual(self.jaanch, worker_base.do_work(**self.jaanch))
 
     def test_do_work(self):
         fake_result = 'fake_result'
@@ -64,10 +63,9 @@ class WorkBaseTest(unittest.TestCase):
             return 10
 
         self._register_plugin().work = work
-        exp_jaanch = self.jaanch['jaanch']
+        exp_jaanch = self.jaanch
         exp_jaanch['input']['result'] = 10
-        self.assertDictEqual(exp_jaanch,
-                             work('fake_worker', **self.jaanch['jaanch']))
+        self.assertDictEqual(exp_jaanch, work('fake_worker', **self.jaanch))
 
     def test_match_expected_output(self):
 
@@ -76,14 +74,13 @@ class WorkBaseTest(unittest.TestCase):
             return 10
 
         self._register_plugin().work = work
-        exp_jaanch = self.jaanch['jaanch']
+        exp_jaanch = self.jaanch
         jaanch = self.jaanch
-        jaanch['jaanch']['output']['result'] = 10
+        jaanch['output']['result'] = 10
         exp_jaanch['output']['result'] = 10
         exp_jaanch['input']['result'] = True
 
-        self.assertDictEqual(exp_jaanch,
-                             work('fake_worker', **jaanch['jaanch']))
+        self.assertDictEqual(exp_jaanch, work('fake_worker', **jaanch))
 
     def test_if_args_are_not_provided_at_all(self):
         @plugins.register('ini')
@@ -103,4 +100,4 @@ class WorkBaseTest(unittest.TestCase):
                 pass
 
         self.assertRaises(exceptions.ExtraArgsException,
-                          FakePlugin().func, **self.jaanch['jaanch'])
+                          FakePlugin().func, **self.jaanch)

--- a/nirikshak/workers/base.py
+++ b/nirikshak/workers/base.py
@@ -14,6 +14,7 @@
 
 from abc import ABCMeta
 from abc import abstractmethod
+import copy
 import logging
 import six
 
@@ -68,8 +69,6 @@ def match_expected_output(validator):
 
 
 def do_work(**kwargs):
-    key = list(kwargs.keys())[0]
-    kwargs = kwargs[key]
     try:
         worker = kwargs['type']
     except KeyError:
@@ -77,12 +76,13 @@ def do_work(**kwargs):
         return kwargs
 
     plugin = plugins.get_plugin(worker)
+    result = copy.deepcopy(kwargs)
     try:
         result = getattr(plugin, 'work')(**kwargs)
     except Exception:
         LOG.error("%s worker failed", exc_info=True)
         return kwargs
     else:
-        LOG.info("%s jaanch has been completed by the plugin", key)
+        LOG.info("%s jaanch has been completed by the plugin", kwargs['name'])
 
     return result

--- a/nirikshak/workers/files/ini.py
+++ b/nirikshak/workers/files/ini.py
@@ -15,7 +15,7 @@
 import logging
 try:
     import configparser
-except ImportError:
+except ImportError:                        # pragma: no cover
     import ConfigParser as configparser
 
 from nirikshak.common import plugins


### PR DESCRIPTION
Existing input format had following format

'jaanch_name': {
     'key1': value1
     'key2': value2
}

It is un necessary to have 'jaanch_name' as key and value of jaanch as value. It brings un necessary complexity for parsing of jaanch. Therefore it has been changed in following format

{
  'name': 'jaanch_name',
  'key1': 'value1',
  'key2': 'value2
}